### PR TITLE
Update time since posted format to use days.

### DIFF
--- a/src/window.go
+++ b/src/window.go
@@ -603,10 +603,12 @@ func (w *Window) AddPreview(a *Article) {
 func GetTime(ts string) string {
   d_rex := regexp.MustCompile(`(\d+)h`)
   d_res := d_rex.FindStringSubmatch(ts)
-  if i, err := strconv.Atoi(d_res[1]); err == nil {
-    if i > 23 {
-      days := i / 24
-      return strconv.Itoa(days) + "d"
+  if len(d_res) > 0 {
+    if i, err := strconv.Atoi(d_res[1]); err == nil {
+      if i > 23 {
+        days := i / 24
+        return strconv.Itoa(days) + "d"
+      }
     }
   }
 

--- a/src/window.go
+++ b/src/window.go
@@ -605,7 +605,7 @@ func GetTime(ts string) string {
   d_res := d_rex.FindStringSubmatch(ts)
   if i, err := strconv.Atoi(d_res[1]); err == nil {
     if i > 23 {
-      days := s / 24
+      days := i / 24
       return strconv.Itoa(days) + "d"
     }
   }

--- a/src/window.go
+++ b/src/window.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+  "strconv"
 )
 
 // Window holds all information regarding the Window layout and functionality
@@ -543,13 +544,7 @@ func (w *Window) AddToArticles(a *Article, markedWeb bool) {
 	}
 
 	str := time.Since(a.published).Round(time.Minute).String()
-	rex := regexp.MustCompile(`.*m(.*?)`)
-	res := rex.FindAllStringSubmatch(str, -1)
-
-	t := "-"
-	if len(res) > 0 && res[0] != nil {
-		t = string(res[0][0])
-	}
+  t := GetTime(str)
 
 	dc := tview.NewTableCell(
 		fmt.Sprintf(
@@ -602,4 +597,24 @@ func (w *Window) AddPreview(a *Article) {
 	)
 	w.preview.SetText(text)
 	w.preview.ScrollToBeginning()
+}
+
+// GetTime returns the timestring formatted as (%h%m < 24 hours < %d)
+func GetTime(ts string) string {
+  d_rex := regexp.MustCompile(`(\d+)h`)
+  d_res := d_rex.FindStringSubmatch(ts)
+  if i, err := strconv.Atoi(d_res[1]); err == nil {
+    if i > 23 {
+      days := s / 24
+      return strconv.Itoa(days) + "d"
+    }
+  }
+
+  rex := regexp.MustCompile(`.*m(.*?)`)
+  res := rex.FindAllStringSubmatch(ts, -1)
+  if len(res) > 0 && res[0] != nil {
+    return string(res[0][0])
+  }
+
+  return "-"
 }


### PR DESCRIPTION
This patch shows the time in days for posts over a day old.
Old format: 192h
New format: 8d