### PR TITLE
Customise feed titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ to use with the argument `-db` to the binary.
 
 ## Configuration Example (Default config)
 It's possible to specify configuration file as a flag, default is `gorss.conf`.
+
+The configuration file can specify URLs of feeds as strings, or, if you want to
+customise the name of the feed as it is shown in your Gorss, as objects with url
+and name fields. (See the example below for supported options).
 ```
 ./gorss -config my.conf
 ```
@@ -71,10 +75,10 @@ It's possible to specify configuration file as a flag, default is `gorss.conf`.
     "OPMLFile": "../example_ompl.xml",
     "feeds": [
         "https://news.ycombinator.com/rss",
-        "https://www.sweclockers.com/feeds/nyheter",
-        "https://www.reddit.com/r/homeassistant/.rss",
-        "https://www.reddit.com/r/golang/.rss",
-        "https://www.reddit.com/r/programming/.rss"
+        ("url": "https://www.sweclockers.com/feeds/nyheter", "name": "Swedish Overclocking"},
+        ("url": "https://www.reddit.com/r/homeassistant/.rss", "name": "Home Assistant"},
+        ("url": "https://www.reddit.com/r/golang/.rss"},
+        {"url": "https://www.reddit.com/r/programming/.rss"}
     ],
     "feedWindowSizeRatio": 2,
     "articlePreviewWindowSizeRatio": 5,

--- a/gorss.conf
+++ b/gorss.conf
@@ -8,10 +8,10 @@
     "OPMLFile": "../example_ompl.xml",
     "feeds": [
         "https://news.ycombinator.com/rss",
-        "https://www.sweclockers.com/feeds/nyheter",
-        "https://www.reddit.com/r/homeassistant/.rss",
-        "https://www.reddit.com/r/golang/.rss",
-        "https://www.reddit.com/r/programming/.rss"
+        {"url": "https://www.sweclockers.com/feeds/nyheter", "name": "Swedish Overclocking"},
+        {"url": "https://www.reddit.com/r/homeassistant/.rss", "name": "Home Assistant"},
+        {"url": "https://www.reddit.com/r/golang/.rss"},
+        {"url": "https://www.reddit.com/r/programming/.rss"}
     ],
     "feedWindowSizeRatio": 2,
     "articlePreviewWindowSizeRatio": 5,

--- a/internal/article.go
+++ b/internal/article.go
@@ -6,14 +6,15 @@ import (
 
 // Article holds the content of a feed item
 type Article struct {
-	c         *Controller
-	id        int
-	feed      string
-	title     string
-	content   string
-	link      string
-	read      bool
-	deleted   bool
-	highlight bool
-	published time.Time
+	c           *Controller
+	id          int
+	feed        string
+	feedDisplay string
+	title       string
+	content     string
+	link        string
+	read        bool
+	deleted     bool
+	highlight   bool
+	published   time.Time
 }

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -2,8 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"github.com/gdamore/tcell"
-	"github.com/rivo/tview"
 	"log"
 	"os"
 	"os/exec"
@@ -13,6 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gdamore/tcell"
+	"github.com/rivo/tview"
 )
 
 // Controller handles the logic and keep everything together

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -69,7 +69,7 @@ func (c *Controller) Init(cfg, theme, db string) {
 // GetConfigKeys creates a list of keys that we want to present
 // in the help section.
 func (c *Controller) GetConfigKeys() map[string]string {
-	keys := make(map[string]string, 0)
+	keys := make(map[string]string)
 
 	keys["Open Link"] = c.conf.KeyOpenLink
 	keys["Mark Link"] = c.conf.KeyMarkLink
@@ -247,8 +247,8 @@ func (c *Controller) ShowFeeds() {
 		count   int
 		display string
 	}
-	feeds := make(map[string]*feed, 0)
-	feedsTotal := make(map[string]int, 0)
+	feeds := make(map[string]*feed)
+	feedsTotal := make(map[string]int)
 	urTotal := 0
 	total = 0
 	for _, a := range c.articles {

--- a/internal/db.go
+++ b/internal/db.go
@@ -34,6 +34,7 @@ func (d *DB) Init(c *Controller, dbFile string) error {
 			content text,
 			link text,
 			read bool,
+			display_name string,
 			deleted bool,
 			published DATETIME
 		);`)
@@ -75,7 +76,7 @@ func (d *DB) CleanupDB() {
 
 // All fetches all articles from the database
 func (d *DB) All() []Article {
-	st, err := d.db.Prepare("select id,feed,title,content,published,link,read from articles where deleted = false order by id")
+	st, err := d.db.Prepare("select id,feed,title,content,published,link,read,display_name from articles where deleted = false order by id")
 	if err != nil {
 		log.Println(err)
 		return nil
@@ -96,13 +97,14 @@ func (d *DB) All() []Article {
 		feed      string
 		link      string
 		read      bool
+		display   string
 		published time.Time
 	)
 
 	articles := []Article{}
 
 	for rows.Next() {
-		err = rows.Scan(&id, &feed, &title, &content, &published, &link, &read)
+		err = rows.Scan(&id, &feed, &title, &content, &published, &link, &read, &display)
 		if err != nil {
 			log.Println(err)
 		}
@@ -121,7 +123,7 @@ func (d *DB) All() []Article {
 				break
 			}
 		}
-		articles = append(articles, Article{id: id, highlight: highlight, feed: feed, title: title, content: content, published: published, link: link, read: read})
+		articles = append(articles, Article{id: id, highlight: highlight, feed: feed, title: title, content: content, published: published, link: link, read: read, feedDisplay: display})
 	}
 	return articles
 }
@@ -149,13 +151,13 @@ func (d *DB) Save(a Article) error {
 		log.Println(err)
 	}
 
-	st, err = tx.Prepare("insert into articles(feed, title, content, link, read, published, deleted) values(?, ?, ?, ?, ?,?,?)")
+	st, err = tx.Prepare("insert into articles(feed, title, content, link, read, display_name, published, deleted) values(?, ?, ?, ?, ?, ?, ?,?)")
 	if err != nil {
 		log.Println(err)
 	}
 	defer st.Close()
 
-	if _, err := st.Exec(a.feed, a.title, a.content, a.link, false, a.published, false); err != nil {
+	if _, err := st.Exec(a.feed, a.title, a.content, a.link, false, a.feedDisplay, a.published, false); err != nil {
 		log.Println(err)
 	}
 

--- a/internal/db.go
+++ b/internal/db.go
@@ -28,9 +28,9 @@ func (d *DB) Init(c *Controller, dbFile string) error {
 
 	_, err = d.db.Exec(`
          create table if not exists articles(
-			id integer not null primary key, 
+			id integer not null primary key,
 			feed text,
-			title text, 
+			title text,
 			content text,
 			link text,
 			read bool,

--- a/internal/rss.go
+++ b/internal/rss.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/gilliek/go-opml/opml"
 	"github.com/mmcdole/gofeed"
@@ -37,13 +36,13 @@ func (r *RSS) Init(c *Controller) {
 				for _, o := range b.Outlines {
 					url := r.GetURLFromOPML(o)
 					if url != "" {
-						r.c.conf.Feeds = append(r.c.conf.Feeds, url)
+						r.c.conf.Feeds = append(r.c.conf.Feeds, Feed{URL: url})
 					}
 				}
 			} else {
 				url := r.GetURLFromOPML(b)
 				if url != "" {
-					r.c.conf.Feeds = append(r.c.conf.Feeds, url)
+					r.c.conf.Feeds = append(r.c.conf.Feeds, Feed{URL: url})
 				}
 			}
 		}
@@ -71,21 +70,16 @@ func (r *RSS) Update() {
 		feed        *gofeed.Feed
 	}{}
 	for _, f := range r.c.conf.Feeds {
-		sf := strings.Split(f, "~")
-		feed, err := r.FetchURL(fp, strings.TrimSpace(sf[0]))
+		feed, err := r.FetchURL(fp, f.URL)
 		if err != nil {
-			log.Printf("error fetching url: %s, err: %v", f, err)
+			log.Printf("error fetching url: %s, err: %v", f.URL, err)
 			continue
-		}
-		dname := ""
-		if len(sf) > 1 {
-			dname = strings.TrimSpace(sf[1])
 		}
 		r.feeds = append(r.feeds, struct {
 			displayName string
 			feed        *gofeed.Feed
 		}{
-			dname,
+			f.Name,
 			feed,
 		})
 	}

--- a/internal/window.go
+++ b/internal/window.go
@@ -35,6 +35,13 @@ type Window struct {
 	nFeeds      int
 }
 
+const (
+	// KeyCell -
+	KeyCell = iota
+	// ActionCell -
+	ActionCell
+)
+
 // Init sets up all information regarding widgets
 func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Controller) {
 	w.c = c
@@ -69,13 +76,13 @@ func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Contro
 	ts.SetAlign(tview.AlignLeft)
 	ts.Attributes |= tcell.AttrBold
 	ts.SetSelectable(false)
-	w.help.SetCell(0, 0, ts)
+	w.help.SetCell(0, KeyCell, ts)
 
 	ts = tview.NewTableCell("Action")
 	ts.SetAlign(tview.AlignLeft)
 	ts.Attributes |= tcell.AttrBold
 	ts.SetSelectable(false)
-	w.help.SetCell(0, 1, ts)
+	w.help.SetCell(0, ActionCell, ts)
 
 	i := 1
 	configKeys := c.GetConfigKeys()
@@ -93,14 +100,14 @@ func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Contro
 		ts.Attributes |= tcell.AttrBold
 		ts.SetSelectable(false)
 		ts.SetTextColor(tcell.GetColor(w.c.theme.StatusKey))
-		w.help.SetCell(i, 0, ts)
+		w.help.SetCell(i, KeyCell, ts)
 
 		ts = tview.NewTableCell(fmt.Sprintf("%s", k))
 		ts.SetAlign(tview.AlignLeft)
 		ts.SetTextColor(tcell.GetColor(w.c.theme.StatusText))
 		ts.Attributes |= tcell.AttrBold
 		ts.SetSelectable(false)
-		w.help.SetCell(i, 1, ts)
+		w.help.SetCell(i, ActionCell, ts)
 	}
 
 	// Preview window
@@ -387,14 +394,14 @@ func (w *Window) ClearFeeds() {
 }
 
 // AddToFeeds add a new feed to the feed window
-func (w *Window) AddToFeeds(name string, unread, total int, ref *Article) {
+func (w *Window) AddToFeeds(name, displayName string, unread, total int, ref *Article) {
 	w.nFeeds++
 
 	color := "white"
 	if len(w.c.conf.Feeds) < len(w.c.theme.FeedNames) {
 		idx := 0
 		for i, f := range w.c.rss.feeds {
-			if f.Title == name {
+			if f.feed.Title == name {
 				idx = i
 				break
 			}
@@ -416,7 +423,11 @@ func (w *Window) AddToFeeds(name string, unread, total int, ref *Article) {
 	nc.SetSelectable(true)
 	nc.SetTextColor(tcell.GetColor(w.c.theme.UnreadColumn))
 
-	nc = tview.NewTableCell(fmt.Sprintf("%s", name))
+	// Display the name of the feed
+	if displayName == "" {
+		displayName = name
+	}
+	nc = tview.NewTableCell(fmt.Sprintf("%s", displayName))
 	nc.SetAlign(tview.AlignLeft)
 	w.feeds.SetCell(w.nFeeds, 2, nc)
 	nc.SetSelectable(true)
@@ -520,7 +531,7 @@ func (w *Window) AddToArticles(a *Article, markedWeb bool) {
 	if len(w.c.conf.Feeds) < len(w.c.theme.FeedNames) {
 		idx := 0
 		for i, f := range w.c.rss.feeds {
-			if f.Title == a.feed {
+			if f.feed.Title == a.feed {
 				idx = i
 				break
 			}

--- a/internal/window.go
+++ b/internal/window.go
@@ -2,15 +2,16 @@ package internal
 
 import (
 	"fmt"
-	"github.com/gdamore/tcell"
-	"github.com/rivo/tview"
-	"jaytaylor.com/html2text"
 	"log"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
-  "strconv"
+
+	"github.com/gdamore/tcell"
+	"github.com/rivo/tview"
+	"jaytaylor.com/html2text"
 )
 
 // Window holds all information regarding the Window layout and functionality
@@ -41,12 +42,14 @@ func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Contro
 	w.showPreview = true
 	w.showHelp = false
 
+	// Feeds window
 	w.feeds = tview.NewTable()
 	w.feeds.SetBorder(true)
 	w.feeds.SetBorderPadding(1, 1, 1, 1)
 	w.feeds.SetBorderColor(tcell.GetColor(w.c.theme.FeedBorder))
 	w.feeds.SetTitle(fmt.Sprintf("%s Feeds", w.c.theme.FeedIcon)).SetTitleColor(tcell.GetColor(w.c.theme.FeedBorderTitle))
 
+	// Articles window
 	w.articles = tview.NewTable()
 	w.articles.SetTitleAlign(tview.AlignLeft)
 	w.articles.SetBorder(true)
@@ -54,6 +57,7 @@ func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Contro
 	w.articles.SetBorderColor(tcell.GetColor(w.c.theme.ArticleBorder))
 	w.articles.SetTitle(fmt.Sprintf("%s Articles", w.c.theme.ArticleIcon)).SetTitleColor(tcell.GetColor(w.c.theme.ArticleBorderTitle))
 
+	// Help window
 	w.help = tview.NewTable()
 	w.help.SetTitleAlign(tview.AlignLeft)
 	w.help.SetBorder(true)
@@ -81,6 +85,7 @@ func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Contro
 	}
 	sort.Strings(keys)
 
+	// Populate help window
 	for _, k := range keys {
 		i++
 		ts = tview.NewTableCell(fmt.Sprintf("%s", configKeys[k]))
@@ -98,6 +103,7 @@ func (w *Window) Init(inputFunc func(*tcell.EventKey) *tcell.EventKey, c *Contro
 		w.help.SetCell(i, 1, ts)
 	}
 
+	// Preview window
 	w.preview = tview.NewTextView()
 	w.preview.SetBorder(true)
 	w.preview.SetBorderPadding(1, 1, 1, 1)
@@ -396,12 +402,14 @@ func (w *Window) AddToFeeds(name string, unread, total int, ref *Article) {
 		color = w.c.theme.FeedNames[idx]
 	}
 
+	// Display total number of articles
 	nc := tview.NewTableCell(fmt.Sprintf("%d", total))
 	nc.SetAlign(tview.AlignLeft)
 	w.feeds.SetCell(w.nFeeds, 0, nc)
 	nc.SetSelectable(true)
 	nc.SetTextColor(tcell.GetColor(w.c.theme.TotalColumn))
 
+	// Display number of unread articles
 	nc = tview.NewTableCell(fmt.Sprintf("%d", unread))
 	nc.SetAlign(tview.AlignLeft)
 	w.feeds.SetCell(w.nFeeds, 1, nc)
@@ -556,7 +564,7 @@ func (w *Window) AddToArticles(a *Article, markedWeb bool) {
 	}
 
 	str := time.Since(a.published).Round(time.Minute).String()
-  t := GetTime(str)
+	t := GetTime(str)
 
 	dc := tview.NewTableCell(
 		fmt.Sprintf(
@@ -613,22 +621,22 @@ func (w *Window) AddPreview(a *Article) {
 
 // GetTime returns the timestring formatted as (%h%m < 24 hours < %d)
 func GetTime(ts string) string {
-  d_rex := regexp.MustCompile(`(\d+)h`)
-  d_res := d_rex.FindStringSubmatch(ts)
-  if len(d_res) > 0 {
-    if i, err := strconv.Atoi(d_res[1]); err == nil {
-      if i > 23 {
-        days := i / 24
-        return strconv.Itoa(days) + "d"
-      }
-    }
-  }
+	d_rex := regexp.MustCompile(`(\d+)h`)
+	d_res := d_rex.FindStringSubmatch(ts)
+	if len(d_res) > 0 {
+		if i, err := strconv.Atoi(d_res[1]); err == nil {
+			if i > 23 {
+				days := i / 24
+				return strconv.Itoa(days) + "d"
+			}
+		}
+	}
 
-  rex := regexp.MustCompile(`.*m(.*?)`)
-  res := rex.FindAllStringSubmatch(ts, -1)
-  if len(res) > 0 && res[0] != nil {
-    return string(res[0][0])
-  }
+	rex := regexp.MustCompile(`.*m(.*?)`)
+	res := rex.FindAllStringSubmatch(ts, -1)
+	if len(res) > 0 && res[0] != nil {
+		return string(res[0][0])
+	}
 
-  return "-"
+	return "-"
 }

--- a/internal/window.go
+++ b/internal/window.go
@@ -265,7 +265,7 @@ func (w *Window) StatusUpdate() {
 
 	c = w.status.GetCell(0, 3)
 	unread := 0
-	feeds := make(map[string]struct{}, 0)
+	feeds := make(map[string]struct{})
 	for _, a := range w.c.articles {
 		if _, ok := feeds[a.feed]; !ok {
 			feeds[a.feed] = struct{}{}


### PR DESCRIPTION
Added a field to the database that is populated with the display name for the feed.

The config file feeds strings will be split on the '~' char, with the first section being the url to fetch, and the second (optional) section being the name displayed in the window.

This *only* changes the name in the feeds window, *not* the name in the article window - please let me know if a change is preferred

This change will not work with an existing copy of the database, to use this version will require execution of the following command (assuming this is where the database is on your local system) `mv ~/.local/share/gorss/gorss.db{,.bkup}`

Currently the display is tightly coupled to the fetching of the URL, I feel that this should be re-architected, but this PR may not be the right place to do that.