### PR TITLE
Add keybindings for feeds column scrolling

### DIFF
--- a/gorss.conf
+++ b/gorss.conf
@@ -29,6 +29,8 @@
     "keyDeleteArticle": "d",
     "keyMoveDown": "s",
     "keyMoveUp": "w",
+    "keyFeedDown": "S",
+    "keyFeedUp": "W",
     "keySortByDate": "r",
     "keySortByUnread": "e",
     "keySortByTitle": "t",
@@ -46,11 +48,11 @@
     "keyUndoLastRead": "u",
     "keySearchPromt": "/",
     "customCommands": [
-        { 
+        {
             "key": "j",
             "Cmd": "echo 'ARTICLE.Content' 'ARTICLE.Link' > /tmp/test2.txt"
         },
-        { 
+        {
             "key": "k",
             "Cmd": "echo 'ARTICLE.Title' 'ARTICLE.Feed' > /tmp/test.txt"
         }

--- a/internal/config.go
+++ b/internal/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	KeyDeleteArticle              string        `json:"keyDeleteArticle"`
 	KeyMoveDown                   string        `json:"keyMoveDown"`
 	KeyMoveUp                     string        `json:"keyMoveUp"`
+	KeyFeedDown                   string        `json:"keyFeedDown"`
+	KeyFeedUp                     string        `json:"keyFeedUp"`
 	KeySortByDate                 string        `json:"keySortByDate"`
 	KeySortByTitle                string        `json:"keySortByTitle"`
 	KeySortByUnread               string        `json:"keySortByUnread"`

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -518,10 +518,16 @@ func (c *Controller) Input(e *tcell.EventKey) *tcell.EventKey {
 		if c.activeFeed == "unread" {
 			c.win.articles.Select(0, 3)
 		}
-		c.win.MoveDown()
+		c.win.MoveDown(c.win.app.GetFocus())
 
 	case c.conf.KeyMoveUp, "Up":
-		c.win.MoveUp()
+		c.win.MoveUp(c.win.app.GetFocus())
+
+	case c.conf.KeyFeedDown:
+		c.win.MoveDown(c.win.feeds)
+
+	case c.conf.KeyFeedUp:
+		c.win.MoveUp(c.win.feeds)
 
 	case c.conf.KeySortByFeed:
 		sort.Slice(c.articles, func(i, j int) bool {

--- a/internal/window.go
+++ b/internal/window.go
@@ -525,16 +525,15 @@ func (w *Window) ArticlesHasFocus() bool {
 }
 
 // MoveDown handles a keypress for moving down in feeds/articles
-func (w *Window) MoveDown() {
-	p := w.app.GetFocus()
+func (w *Window) MoveDown(focus tview.Primitive) {
 	// Article window
-	if p == w.articles {
+	if focus == w.articles {
 		count := w.articles.GetRowCount()
 		r, _ := w.articles.GetSelection()
 		if r < count-1 {
 			w.articles.Select(r+1, 3)
 		}
-	} else if p == w.feeds {
+	} else if focus == w.feeds {
 		// Feed window
 		count := w.feeds.GetRowCount()
 		r, _ := w.feeds.GetSelection()
@@ -543,7 +542,7 @@ func (w *Window) MoveDown() {
 		}
 		// Set selected article to first article in feed
 		w.articles.Select(0, 3)
-	} else if p == w.preview {
+	} else if focus == w.preview {
 		// Preview window
 		r, _ := w.preview.GetScrollOffset()
 		w.preview.ScrollTo(r+1, 0)
@@ -551,19 +550,18 @@ func (w *Window) MoveDown() {
 }
 
 // MoveUp handles a keypress for moving up in feeds/articles
-func (w *Window) MoveUp() {
-	p := w.app.GetFocus()
-	if p == w.articles {
+func (w *Window) MoveUp(focus tview.Primitive) {
+	if focus == w.articles {
 		r, _ := w.articles.GetSelection()
 		if r > 1 {
 			w.articles.Select(r-1, 3)
 		}
-	} else if p == w.feeds {
+	} else if focus == w.feeds {
 		r, _ := w.feeds.GetSelection()
 		if r > 1 {
 			w.feeds.Select(r-1, 0)
 		}
-	} else if p == w.preview {
+	} else if focus == w.preview {
 		r, _ := w.preview.GetScrollOffset()
 		w.preview.ScrollTo(r-1, 0)
 	}


### PR DESCRIPTION
I've been using gorss as my daily driver for youtube subscriptions for a few weeks now, and I find that when you have a lot of feeds with only a few updates, and you're not looking at everything chronologically, it's a lot more comfortable being able to skip the `tab` window selection.

This PR allows users to keep the focus on the Article windows while at the same time scrolling through their Feeds. Right now it's not perfectly polished with regard to the existing window switching, but I mostly want to gauge interest in this feature :) 

On my setup I use `Ctrl+J,K`, but given the existing default keybinds that gorss uses, that didn't make a lot of sense, and people definitely expect something else from `Ctrl+S,W` ^^