### PR TITLE
controller: override default browser

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -47,7 +47,12 @@ type Config struct {
 	KeyQuit                       string        `json:"keyQuit"`
 	KeyUndoLastRead               string        `json:"keyUndoLastRead"`
 	KeySearchPromt                string        `json:"keySearchPromt"`
-	CustomCommands                []Command     `json:"customCommands"`
+	// WebBrowser overrides the default program used to open links. Default one depends on the OS:
+	// * `xdg-open` for Linux
+	// * `url.dll,FileProtocolHandler` for Windows
+	// * `open` for Darwin
+	WebBrowser     string    `json:"webBrowser"`
+	CustomCommands []Command `json:"customCommands"`
 }
 
 // Feed -

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -217,6 +217,15 @@ func (c *Controller) GetArticlesFromDB() {
 func (c *Controller) OpenLink(link string) {
 	var err error
 
+	browser := c.conf.WebBrowser
+	if browser != "" {
+		if err = exec.Command(browser, link).Start(); err != nil {
+			log.Println("unable to open %s on %s: %v", link, browser, err)
+		}
+
+		return
+	}
+
 	switch runtime.GOOS {
 	case "linux":
 		err = exec.Command("xdg-open", link).Start()


### PR DESCRIPTION
Hi,

In this PR, we add a new configuration key `webBrowser` to allow one to override the default program to open a browser.

For example, on my Linux, I do not have `xdg-open` - so I use directly `firefox` to open the link with:
```json
{
...
    "webBrowser": "firefox-bin"
}
```

Thanks for this software :) 