### PR TITLE
Use XDG_CONFIG_HOME for config and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ You can also specify theme, configuration and database manually.
 ./gorss -config gorss.conf -theme default.theme -db mydb.db
 ```
 
-Gorss expect to have `gorss.conf` and `default.theme` in the same directory as `gorss` itself if not
-starting it with parameters as above.
+If either the configuration or theme files are not specified, gorss will attempt
+to use`$XDG_CONFIG_HOME/gorss/gorss.conf` and
+`$XDG_CONFIG_HOME/gorss/themes/default.theme`, respectively.  These files will be
+created from the defaults if not present.
 
 To build and run use the makefile.
 ```

--- a/cmd/gorss/main.go
+++ b/cmd/gorss/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+        "errors"
 	"flag"
 	"fmt"
 	"log"
@@ -57,6 +58,11 @@ func main() {
 			cfg = s
 		} else {
 			cfg = fmt.Sprintf("%s/%s", configHome, defaultConfig)
+                        // check if default config exists, copy if not
+                        _, err := os.Stat(cfg)
+                        if errors.Is(err, os.ErrNotExist) {
+                            internal.CopyFile(defaultConfig, cfg)
+                        }
 		}
 	}
 
@@ -67,6 +73,15 @@ func main() {
 			theme = s
 		} else {
 			theme = fmt.Sprintf("%s/%s", configHome, defaultTheme)
+                        // check if default config exists, copy if not
+                        _, err := os.Stat(theme)
+                        if errors.Is(err, os.ErrNotExist) {
+                            themeDir := fmt.Sprintf("%s/%s", configHome, "themes")
+                            if err := os.Mkdir(themeDir, os.ModePerm); err != nil {
+                                log.Printf("Failed to create dir: %s\n", themeDir)
+                            }
+                            internal.Copy(defaultTheme, theme)
+                        }
 		}
 	}
 

--- a/cmd/gorss/main.go
+++ b/cmd/gorss/main.go
@@ -80,7 +80,7 @@ func main() {
                             if err := os.Mkdir(themeDir, os.ModePerm); err != nil {
                                 log.Printf("Failed to create dir: %s\n", themeDir)
                             }
-                            internal.Copy(defaultTheme, theme)
+                            internal.CopyFile(defaultTheme, theme)
                         }
 		}
 	}

--- a/cmd/gorss/main.go
+++ b/cmd/gorss/main.go
@@ -55,6 +55,8 @@ func main() {
 		s := conf.QueryConfig(defaultConfig)
 		if s != "" {
 			cfg = s
+		} else {
+			cfg = fmt.Sprintf("%s/%s", configHome, defaultConfig)
 		}
 	}
 
@@ -63,6 +65,8 @@ func main() {
 		s := conf.QueryConfig(defaultTheme)
 		if s != "" {
 			theme = s
+		} else {
+			theme = fmt.Sprintf("%s/%s", configHome, defaultTheme)
 		}
 	}
 

--- a/cmd/gorss/main.go
+++ b/cmd/gorss/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-        "errors"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -58,11 +58,11 @@ func main() {
 			cfg = s
 		} else {
 			cfg = fmt.Sprintf("%s/%s", configHome, defaultConfig)
-                        // check if default config exists, copy if not
-                        _, err := os.Stat(cfg)
-                        if errors.Is(err, os.ErrNotExist) {
-                            internal.CopyFile(defaultConfig, cfg)
-                        }
+			// check if default config exists, copy if not
+			_, err := os.Stat(cfg)
+			if errors.Is(err, os.ErrNotExist) {
+				internal.CopyFile(defaultConfig, cfg)
+			}
 		}
 	}
 
@@ -73,15 +73,15 @@ func main() {
 			theme = s
 		} else {
 			theme = fmt.Sprintf("%s/%s", configHome, defaultTheme)
-                        // check if default config exists, copy if not
-                        _, err := os.Stat(theme)
-                        if errors.Is(err, os.ErrNotExist) {
-                            themeDir := fmt.Sprintf("%s/%s", configHome, "themes")
-                            if err := os.Mkdir(themeDir, os.ModePerm); err != nil {
-                                log.Printf("Failed to create dir: %s\n", themeDir)
-                            }
-                            internal.CopyFile(defaultTheme, theme)
-                        }
+			// check if default config exists, copy if not
+			_, err := os.Stat(theme)
+			if errors.Is(err, os.ErrNotExist) {
+				themeDir := fmt.Sprintf("%s/%s", configHome, "themes")
+				if err := os.Mkdir(themeDir, os.ModePerm); err != nil {
+					log.Printf("Failed to create dir: %s\n", themeDir)
+				}
+				internal.CopyFile(defaultTheme, theme)
+			}
 		}
 	}
 

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+    "fmt"
+    "io"
+    "os"
+)
+
+// copy file from src to dst
+func CopyFile(src, dst string) (int64, error) {
+    sourceFileStat, err := os.Stat(src)
+    if err != nil {
+            return 0, err
+    }
+
+    if !sourceFileStat.Mode().IsRegular() {
+            return 0, fmt.Errorf("%s is not a regular file", src)
+    }
+
+    source, err := os.Open(src)
+    if err != nil {
+            return 0, err
+    }
+    defer source.Close()
+
+    destination, err := os.Create(dst)
+    if err != nil {
+            return 0, err
+    }
+    defer destination.Close()
+    nBytes, err := io.Copy(destination, source)
+    return nBytes, err
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,33 +1,33 @@
 package internal
 
 import (
-    "fmt"
-    "io"
-    "os"
+	"fmt"
+	"io"
+	"os"
 )
 
 // copy file from src to dst
 func CopyFile(src, dst string) (int64, error) {
-    sourceFileStat, err := os.Stat(src)
-    if err != nil {
-            return 0, err
-    }
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
 
-    if !sourceFileStat.Mode().IsRegular() {
-            return 0, fmt.Errorf("%s is not a regular file", src)
-    }
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
 
-    source, err := os.Open(src)
-    if err != nil {
-            return 0, err
-    }
-    defer source.Close()
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
 
-    destination, err := os.Create(dst)
-    if err != nil {
-            return 0, err
-    }
-    defer destination.Close()
-    nBytes, err := io.Copy(destination, source)
-    return nBytes, err
+	destination, err := os.Create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
 }


### PR DESCRIPTION
Addresses #33.  Copies the default config and/or theme if they do not exist.  Perhaps there was a reason XDG defaults were not used for config but this was helpful for my use case.  Happy to modify.  Thanks for the great package!